### PR TITLE
refactor internals a bit

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "bencode": "^2.0.1",
-    "ssb-bfe": "^0.2.0"
+    "ssb-bfe": "^0.2.1"
   },
   "devDependencies": {
     "monotonic-timestamp": "^0.0.9",

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,6 +1,6 @@
 const tape = require('tape')
 const timestamp = require('monotonic-timestamp')
-const mfff = require('../')
+const bb = require('../')
 
 tape('encode/decode works', function (t) {
   // a message with lots of different cases, please note the
@@ -29,9 +29,9 @@ tape('encode/decode works', function (t) {
     signature: "F/XZ1uOwXNLKSHynxIvV/FUW1Fd9hIqxJw8TgTbMlf39SbVTwdRPdgxZxp9DoaMIj2yEfm14O0L9kcQJCIW2Cg==.sig.ed25519"
   }
 
-  const encoded = mfff.encode(msg)
+  const encoded = bb.encode(msg)
   t.equal(Buffer.isBuffer(encoded), true, 'buffer')
-  const decoded = mfff.decode(encoded)
+  const decoded = bb.decode(encoded)
   t.deepEqual(decoded, msg, 'properly decoded')
   t.end()
 })
@@ -63,8 +63,8 @@ tape('create', function(t) {
     }
   }
 
-  const msg1 = mfff.create(mainContent, mfKeys, mainKeys, null, 1, timestamp())
-  const msg1Hash = mfff.hash(msg1)
+  const msg1 = bb.create(mainContent, mfKeys, mainKeys, null, 1, timestamp())
+  const msg1Hash = bb.hash(msg1)
 
   t.equal(msg1.previous, null, 'previous correct')
   t.equal(msg1.author, mfKeys.id, 'author correct')
@@ -89,12 +89,12 @@ tape('create', function(t) {
     }
   }
 
-  const msg2 = mfff.create(indexContent, mfKeys, indexKeys, msg1Hash, 2, timestamp())
+  const msg2 = bb.create(indexContent, mfKeys, indexKeys, msg1Hash, 2, timestamp())
 
   t.equal(msg2.previous, msg1Hash)
   t.equal(msg2.sequence, 2, 'sequence correct')
 
-  const msg2network = mfff.decode(mfff.encode(msg2))
+  const msg2network = bb.decode(bb.encode(msg2))
   t.deepEqual(msg2, msg2network)
 
   t.end()

--- a/test/vector.js
+++ b/test/vector.js
@@ -1,12 +1,12 @@
 const tape = require('tape')
 const fs = require('fs')
-const mfff = require('../')
+const bb = require('../')
 const bfe = require('ssb-bfe')
 
 const vec = JSON.parse(fs.readFileSync('test/testvector-metafeed-managment.json', 'utf8'))
 
 tape('vector', function(t) {
-  vec.Entries.forEach(msg => {
+  vec.Entries.forEach((msg, i) => {
     if (msg.HighlevelContent[0].nonce)
       msg.HighlevelContent[0].nonce = Buffer.from(msg.HighlevelContent[0].nonce, 'base64')
 
@@ -19,10 +19,10 @@ tape('vector', function(t) {
       contentSignature: bfe.decode(Buffer.from(msg.HighlevelContent[1].HexString, 'hex')),
       signature: bfe.decode(Buffer.from(msg.Signature, 'hex')),
     }
-    const encoded = mfff.encode(msgExtracted)
+    const encoded = bb.encode(msgExtracted)
 
-    const jsonEncodeDecode = JSON.stringify(mfff.decode(encoded), null, 2)
-    const decode = JSON.stringify(mfff.decode(Buffer.from(msg.EncodedData, 'hex')), null, 2)
+    const jsonEncodeDecode = JSON.stringify(bb.decode(encoded), null, 2)
+    const decode = JSON.stringify(bb.decode(Buffer.from(msg.EncodedData, 'hex')), null, 2)
 
     t.deepEqual(jsonEncodeDecode, decode, 'decode work')
     t.deepEqual(encoded.toString('hex'), msg.EncodedData, 'encode work')


### PR DESCRIPTION
I removed a bit of the `decoded[0][3][1]` jungle, and simplified other code too.

Tests are failing in `test/vectors.js`, but that's a known issue that is pending on cryptix updating the test vector JSON files that are incorrect.