### PR TITLE
Fix payload signature and `sequence` handling in `create()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,13 +103,7 @@ function create(content, mfKeys, sfKeys, previous, sequence, timestamp, boxer) {
       content.recps
     )
 
-  const payload = [
-    mfKeys.public,
-    sequence + 1,
-    previous,
-    timestamp,
-    contentSection,
-  ]
+  const payload = [mfKeys.public, sequence, previous, timestamp, contentSection]
 
   const payloadBFE = bfe.encodeBendyButt(payload)
   const payloadSignature = ssbKeys.sign(mfKeys, bencode.encode(payloadBFE))

--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
   },
   "dependencies": {
     "bencode": "^2.0.1",
-    "ssb-bfe": "^0.2.1"
+    "ssb-bfe": "^0.2.1",
+    "ssb-keys": "^8.1.0"
   },
   "devDependencies": {
     "husky": "^4.3.0",
-    "monotonic-timestamp": "^0.0.9",
     "prettier": "^2.1.2",
     "pretty-quick": "^3.1.0",
     "pull-stream": "^3.6.14",
@@ -21,7 +21,6 @@
     "secret-stack": "^6.4.0",
     "ssb-caps": "^1.1.0",
     "ssb-db2": "^2.1.2",
-    "ssb-keys": "^8.1.0",
     "tap-bail": "^1.0.0",
     "tap-spec": "^5.0.0",
     "tape": "^5.2.2"

--- a/test/basic.js
+++ b/test/basic.js
@@ -70,7 +70,7 @@ tape('create', function (t) {
   t.equal(msg1.previous, null, 'previous correct')
   t.equal(msg1.author, mfKeys.id, 'author correct')
   t.equal(msg1.sequence, 1, 'sequence correct')
-  t.true(msg1.signature.startsWith('QOnqU6'), 'signature is correct')
+  t.equal(msg1.signature.substr(0, 6), 'QOnqU6', 'signature is correct')
 
   const indexKeys = {
     curve: 'ed25519',
@@ -96,7 +96,7 @@ tape('create', function (t) {
 
   t.equal(msg2.previous, msg1Hash)
   t.equal(msg2.sequence, 2, 'sequence correct')
-  t.true(msg2.signature.startsWith('bnHTeQW1'), 'signature is correct')
+  t.equal(msg2.signature.substr(0, 6), 'bnHTeQ', 'signature is correct')
 
   const msg2network = bb.decode(bb.encode(msg2))
   t.deepEqual(msg2, msg2network)

--- a/test/basic.js
+++ b/test/basic.js
@@ -70,7 +70,7 @@ tape('create', function (t) {
   t.equal(msg1.previous, null, 'previous correct')
   t.equal(msg1.author, mfKeys.id, 'author correct')
   t.equal(msg1.sequence, 1, 'sequence correct')
-  t.true(msg1.signature.startsWith('x8dOTj'), 'signature is correct')
+  t.true(msg1.signature.startsWith('QOnqU6'), 'signature is correct')
 
   const indexKeys = {
     curve: 'ed25519',
@@ -96,7 +96,7 @@ tape('create', function (t) {
 
   t.equal(msg2.previous, msg1Hash)
   t.equal(msg2.sequence, 2, 'sequence correct')
-  t.true(msg2.signature.startsWith('Mj6c3mSY'), 'signature is correct')
+  t.true(msg2.signature.startsWith('bnHTeQW1'), 'signature is correct')
 
   const msg2network = bb.decode(bb.encode(msg2))
   t.deepEqual(msg2, msg2network)

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,5 +1,4 @@
 const tape = require('tape')
-const timestamp = require('monotonic-timestamp')
 const bb = require('../')
 
 tape('encode/decode works', function (t) {
@@ -65,12 +64,13 @@ tape('create', function (t) {
     },
   }
 
-  const msg1 = bb.create(mainContent, mfKeys, mainKeys, null, 1, timestamp())
+  const msg1 = bb.create(mainContent, mfKeys, mainKeys, null, 1, 12345)
   const msg1Hash = bb.hash(msg1)
 
   t.equal(msg1.previous, null, 'previous correct')
   t.equal(msg1.author, mfKeys.id, 'author correct')
   t.equal(msg1.sequence, 1, 'sequence correct')
+  t.true(msg1.signature.startsWith('x8dOTj'), 'signature is correct')
 
   const indexKeys = {
     curve: 'ed25519',
@@ -92,17 +92,11 @@ tape('create', function (t) {
     },
   }
 
-  const msg2 = bb.create(
-    indexContent,
-    mfKeys,
-    indexKeys,
-    msg1Hash,
-    2,
-    timestamp()
-  )
+  const msg2 = bb.create(indexContent, mfKeys, indexKeys, msg1Hash, 2, 23456)
 
   t.equal(msg2.previous, msg1Hash)
   t.equal(msg2.sequence, 2, 'sequence correct')
+  t.true(msg2.signature.startsWith('Mj6c3mSY'), 'signature is correct')
 
   const msg2network = bb.decode(bb.encode(msg2))
   t.deepEqual(msg2, msg2network)


### PR DESCRIPTION
Concerning `create(content, mfKeys, sfKeys, previous, sequence, timestamp, boxer)`, the code internally had a `sequence + 1` which looked suspicious to me. I double checked, and I think it was wrong. 

Given that we have the JSDocs now, you can see that we were creating a new `payload` with `sequence + 1` and **signing** it, but what we're actually returning as `msgVal` has `sequence` (without +1).

cc @arj03 FYI