### PR TITLE
Fix author field in the payload, in `create()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,6 +87,7 @@ function encode(msgVal) {
  * @returns {Object} an object compatible with ssb/classic `msg.value`
  */
 function create(content, mfKeys, sfKeys, previous, sequence, timestamp, boxer) {
+  const author = mfKeys.id
   const contentBFE = bfe.encodeBendyButt(content)
   const contentSignature = ssbKeys.sign(sfKeys, bencode.encode(contentBFE))
   const contentSignatureBFE = bfe.encodeBendyButt(contentSignature)
@@ -95,24 +96,22 @@ function create(content, mfKeys, sfKeys, previous, sequence, timestamp, boxer) {
 
   if (content.recps)
     contentSection = boxer(
-      bfe.encodeBendyButt(mfKeys.id),
+      bfe.encodeBendyButt(author),
       bencode.encode(contentSection),
       bfe.encodeBendyButt(previous),
       content.recps
     )
 
-  const payload = [mfKeys.id, sequence, previous, timestamp, contentSection]
-
+  const payload = [author, sequence, previous, timestamp, contentSection]
   const payloadBFE = bfe.encodeBendyButt(payload)
-  const payloadSignature = ssbKeys.sign(mfKeys, bencode.encode(payloadBFE))
-  const payloadSignatureBFE = bfe.encodeBendyButt(payloadSignature)
+  const signature = ssbKeys.sign(mfKeys, bencode.encode(payloadBFE))
 
   const msgVal = {
-    previous,
-    author: mfKeys.id,
+    author,
     sequence,
+    previous,
     timestamp,
-    signature: bfe.decode(payloadSignatureBFE),
+    signature,
   }
 
   if (content.recps) {

--- a/index.js
+++ b/index.js
@@ -101,7 +101,7 @@ function create(content, mfKeys, sfKeys, previous, sequence, timestamp, boxer) {
       content.recps
     )
 
-  const payload = [mfKeys.public, sequence, previous, timestamp, contentSection]
+  const payload = [mfKeys.id, sequence, previous, timestamp, contentSection]
 
   const payloadBFE = bfe.encodeBendyButt(payload)
   const payloadSignature = ssbKeys.sign(mfKeys, bencode.encode(payloadBFE))

--- a/test/basic.js
+++ b/test/basic.js
@@ -70,7 +70,7 @@ tape('create', function (t) {
   t.equal(msg1.previous, null, 'previous correct')
   t.equal(msg1.author, mfKeys.id, 'author correct')
   t.equal(msg1.sequence, 1, 'sequence correct')
-  t.equal(msg1.signature.substr(0, 6), 'QOnqU6', 'signature is correct')
+  t.equal(msg1.signature.substr(0, 6), 'GEb1ml', 'signature is correct')
 
   const indexKeys = {
     curve: 'ed25519',
@@ -96,7 +96,7 @@ tape('create', function (t) {
 
   t.equal(msg2.previous, msg1Hash)
   t.equal(msg2.sequence, 2, 'sequence correct')
-  t.equal(msg2.signature.substr(0, 6), 'bnHTeQ', 'signature is correct')
+  t.equal(msg2.signature.substr(0, 6), 'VIcliJ', 'signature is correct')
 
   const msg2network = bb.decode(bb.encode(msg2))
   t.deepEqual(msg2, msg2network)


### PR DESCRIPTION
It was using `mfKeys.public` when it was supposed to be `mfKeys.id`. It's easiest to review the first commit https://github.com/ssb-ngi-pointer/ssb-bendy-butt/pull/15/commits/4b3d96ed66bf3b828502150353920b5a84596d0e, then the other commit is just refactoring.