### PR TITLE
replace API create() with encodeNew()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,40 @@
-# SSB meta feeds feed format
+# SSB Bendy Butt
 
 Implementation of [bendy butt] in JS
 
-## api
+## API
 
 ### decode(bbmsg)
 
-Takes a bencoded message and returns a classic compatible json object
+Takes a bencoded message and returns an object compatible with the shape of
+`msg.value` under classic SSB feeds.
 
-### encode(msg)
+### encode(msgVal)
 
-Takes a json message value and returns bencoded message buffer
+Takes an object compatible with the shape of `msg.value` under classic SSB feeds
+and returns a bencoded message Buffer.
 
-### create(content, mfKeys, sfKeys, previous, sequence, timestamp, boxer)
+### encodeNew(content, contentKeys, keys, sequence, previousMsgId, timestamp, boxer)
 
-Takes a content json object, meta feed keys, sub feed keys, the
-previous message key on the meta feed or null, the next sequence
-number and a timestamp and returns a classic compatible json
-object. Lastly it takes an boxer function of form (encodedAuthor,
-encodedContent, encodedPrevious, recps) => string (.box2). The encoded
-parts must be in BFE form and recps must be the ids of the recipients.
+Creates a bencoded message Buffer for a new message to be appended to the bendy
+butt feed owned by the author identified by `keys`.
+
+Takes an arbitrary `content` object and an (optional) `contentKeys` which is
+used to sign the content. If `contentKeys` is missing, the signature will be
+done using `keys` instead. The other arguments comprise the metadata section of
+the bendy-butt message, i.e. `author` (deduced from `keys`), `sequence`,
+`previousMsgId` and `timestamp`.
+
+Finally, if the new message is meant to be encrypted to some recipients
+(determined by `content.recps`, an array of feed IDs), then `encodeNew` needs a
+`boxer` function of type `(bbAuthor, bbContentSection, bbPreviousMsgId, recps) => string (.box2)`.
+The arguments `bbAuthor`, `bbContentSection` and `bbPreviousMsgId` must be
+encoded in `bencode` and BFE, and `recps` is the array of recipient IDs.
+
+### hash(msgVal)
+
+Calculate the message key (as a sigil-based string) for the given "msg value"
+(an object with the shape `msg.value` as known in classic SSB feeds).
 
 ### decodeBox2(decryptedBox2)
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -35,7 +35,7 @@ tape('encode/decode works', function (t) {
   t.end()
 })
 
-tape('create', function (t) {
+tape('encodeNew', function (t) {
   const mfKeys = {
     curve: 'ed25519',
     public: 'XCesbvDN+9D4momhtlo2BHejPsect6sUzZB2JVm+4v8=.ed25519',
@@ -64,13 +64,17 @@ tape('create', function (t) {
     },
   }
 
-  const msg1 = bb.create(mainContent, mfKeys, mainKeys, null, 1, 12345)
-  const msg1Hash = bb.hash(msg1)
+  const bbmsg1 = bb.encodeNew(mainContent, mainKeys, mfKeys, 1, null, 12345)
+  const msgVal1 = bb.decode(bbmsg1)
+  const msg1ID = bb.hash(msgVal1)
 
-  t.equal(msg1.previous, null, 'previous correct')
-  t.equal(msg1.author, mfKeys.id, 'author correct')
-  t.equal(msg1.sequence, 1, 'sequence correct')
-  t.equal(msg1.signature.substr(0, 6), 'sJYn08', 'signature is correct')
+  t.equal(msgVal1.author, mfKeys.id, 'author is correct')
+  t.equal(msgVal1.sequence, 1, 'sequence is correct')
+  t.equal(msgVal1.previous, null, 'previous is correct')
+  t.equal(msgVal1.timestamp, 12345, 'timestamp is correct')
+  t.equal(msgVal1.signature.substr(0, 6), 'sJYn08', 'signature is correct')
+  t.deepEquals(msgVal1.content, mainContent, 'content is correct')
+  t.equal(msgVal1.contentSignature.substr(0, 6), 'fglSbg', 'contentSignature')
 
   const indexKeys = {
     curve: 'ed25519',
@@ -92,14 +96,19 @@ tape('create', function (t) {
     },
   }
 
-  const msg2 = bb.create(indexContent, mfKeys, indexKeys, msg1Hash, 2, 23456)
+  const bbmsg2 = bb.encodeNew(indexContent, indexKeys, mfKeys, 2, msg1ID, 23456)
+  const msgVal2 = bb.decode(bbmsg2)
 
-  t.equal(msg2.previous, msg1Hash)
-  t.equal(msg2.sequence, 2, 'sequence correct')
-  t.equal(msg2.signature.substr(0, 6), 'Vsw6a1', 'signature is correct')
+  t.equal(msgVal2.author, mfKeys.id, 'author is correct')
+  t.equal(msgVal2.sequence, 2, 'sequence is correct')
+  t.equal(msgVal2.previous, msg1ID, 'previous is correct')
+  t.equal(msgVal2.timestamp, 23456, 'timestamp is correct')
+  t.equal(msgVal2.signature.substr(0, 6), 'Vsw6a1', 'signature is correct')
+  t.deepEquals(msgVal2.content, indexContent, 'content is correct')
+  t.equal(msgVal2.contentSignature.substr(0, 6), 'gpw1OF', 'contentSignature')
 
-  const msg2network = bb.decode(bb.encode(msg2))
-  t.deepEqual(msg2, msg2network)
+  const msgVal2network = bb.decode(bb.encode(msgVal2))
+  t.deepEqual(msgVal2, msgVal2network)
 
   t.end()
 })


### PR DESCRIPTION
This PR is a bit more opinionated, it's only about developer API. It's replacing `create()` with `encodeNew()`. The primary difference is that `create()` returns a `msg.value` in the classic SSB database message format, which to me sounded like a premature optimization, while `encodeNew` returns the same as `encode` does (i.e. a bbmsg), but the arguments are different. To do the same as before, we should do `encodeNew` followed by a `decode`. The philosophy is that this library should provide bendy-butt-only APIs that are not assuming too much of what you want to do with them.

Other smaller differences are argument order:

```
create(   content, mfKeys, sfKeys, previous, sequence, timestamp, boxer)
encodeNew(content, sfKeys, mfKeys, sequence, previous, timestamp, boxer)
```

The new order has the following reasoning:
`content` and `sfKeys` are adjacent because the only thing that `sfKeys` does is sign the content. In fact I renamed this to `contentKeys` to reflect that functionality, and to decouple this library from metafeeds (metafeeds **use** bendy butt but theoretically not all bendy butt feeds are metafeeds!). And `mfKeys` was renamed to `keys` because it's the primary identity for the new msg.

Then the subsequent arguments mirror the strict order of the payload array, compare the parts in bold:

- encodeNew(content, contentKeys, **keys, sequence, previous, timestamp**, boxer)
- payload = [**author, sequence, previous, timestamp**, content)

(Hmm, perhaps I should move `content` and `contentKeys` to be after `timestamp`?)