### PR TITLE
add test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 pnpm-lock.yaml
+coverage
+.nyc_output

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "husky": "^4.3.0",
+    "nyc": "^15.1.0",
     "prettier": "^2.1.2",
     "pretty-quick": "^3.1.0",
     "pull-stream": "^3.6.14",
@@ -34,6 +35,7 @@
   },
   "scripts": {
     "test": "tape test/*.js | tap-bail | tap-spec",
+    "coverage": "nyc --reporter=lcov npm test",
     "format-code": "prettier --write \"*.js\" \"test/*.js\"",
     "format-code-staged": "pretty-quick --staged --pattern \"*.js\" --pattern \"test/*.js\""
   },


### PR DESCRIPTION
`npm run coverage` produces `./coverage/lcov-report/index.html`, check out this example I deployed here: https://jumpy-sock.surge.sh/index.js.html