### PR TITLE
use SSB URIs for decoded feed IDs and msg IDs

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const ssbKeys = require('ssb-keys')
 const bfe = require('ssb-bfe')
 const ref = require('ssb-ref')
 const SSBURI = require('ssb-uri2')
-const isCanonicalBase64 = require('iscanonicalbase64')
+const isCanonicalBase64 = require('is-canonical-base64')
 
 const CONTENT_SIG_PREFIX = Buffer.from('bendybutt', 'utf8')
 

--- a/index.js
+++ b/index.js
@@ -145,11 +145,7 @@ function encodeNew(
 function hash(msgVal) {
   let data = ssbKeys.hash(encode(msgVal))
   if (data.endsWith('.sha256')) data = data.slice(0, -'.sha256'.length)
-  return SSBURI.compose({
-    type: 'message',
-    format: 'bendybutt-v1',
-    data,
-  })
+  return SSBURI.compose({ type: 'message', format: 'bendybutt-v1', data })
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -2,7 +2,8 @@ const bencode = require('bencode')
 const ssbKeys = require('ssb-keys')
 const bfe = require('ssb-bfe')
 const ref = require('ssb-ref')
-const isCanonicalBase64 = require('is-canonical-base64')
+const SSBURI = require('ssb-uri2')
+const isCanonicalBase64 = require('iscanonicalbase64')
 
 const CONTENT_SIG_PREFIX = Buffer.from('bendybutt', 'utf8')
 
@@ -139,10 +140,16 @@ function encodeNew(
  * Calculate the message key for the given "msg value".
  *
  * @param {Object} msgVal an object compatible with ssb/classic `msg.value`
- * @returns {string} a sigil-based string uniquely identifying the `msgVal`
+ * @returns {string} an SSB URI uniquely identifying the `msgVal`
  */
 function hash(msgVal) {
-  return '%' + ssbKeys.hash(encode(msgVal)).replace('.sha256', '.bbmsg-v1')
+  let data = ssbKeys.hash(encode(msgVal))
+  if (data.endsWith('.sha256')) data = data.slice(0, -'.sha256'.length)
+  return SSBURI.compose({
+    type: 'message',
+    format: 'bendybutt-v1',
+    data,
+  })
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -10,9 +10,10 @@
   "dependencies": {
     "bencode": "^2.0.1",
     "iscanonicalbase64": "^1.0.0",
-    "ssb-bfe": "~2.0.2",
+    "ssb-bfe": "^3.0.0",
     "ssb-keys": "^8.2.0",
-    "ssb-ref": "^2.16.0"
+    "ssb-ref": "^2.16.0",
+    "ssb-uri2": "^1.2.0"
   },
   "devDependencies": {
     "husky": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "bencode": "^2.0.1",
-    "iscanonicalbase64": "^1.0.0",
+    "is-canonical-base64": "^1.1.1",
     "ssb-bfe": "^3.0.0",
     "ssb-keys": "^8.2.0",
     "ssb-ref": "^2.16.0",

--- a/test/basic.js
+++ b/test/basic.js
@@ -6,20 +6,25 @@ tape('encode/decode works', function (t) {
   // a message with lots of different cases, please note the
   // signatures are fake (and not relevant to encode/decode test)
   const msg = {
-    previous: '%H3MlLmVPVgHU6rBSzautUBZibDttkI+cU4lAFUIM8Ag=.bbmsg-v1',
-    author: '@6CAxOI3f+LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4+Uv0=.bbfeed-v1',
+    previous:
+      'ssb:message/bendybutt-v1/H3MlLmVPVgHU6rBSzautUBZibDttkI-cU4lAFUIM8Ag=',
+    author:
+      'ssb:feed/bendybutt-v1/6CAxOI3f-LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4-Uv0=',
     sequence: 2,
     timestamp: 1456154934819,
     content: {
-      type: 'metafeed/add',
+      type: 'metafeed/add/existing',
       feedpurpose: 'test',
-      subfeed: '@6CAxOI3f+LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4+Uv0=.bbfeed-v1',
+      subfeed:
+        'ssb:feed/bendybutt-v1/6CAxOI3f-LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4-Uv0=',
       classichash: '%H3MlLmVPVgHU6rBSzautUBZibDttkI+cU4lAFUIM8Ag=.sha256',
       bool: true,
       tangles: {
         metafeed: {
           root: null,
-          previous: ['%H3MlLmVPVgHU6rBSzautUBZibDttkI+cU4lAFUIM8Ag=.bbmsg-v1'],
+          previous: [
+            'ssb:message/bendybutt-v1/H3MlLmVPVgHU6rBSzautUBZibDttkI-cU4lAFUIM8Ag=',
+          ],
         },
       },
     },
@@ -42,7 +47,7 @@ tape('encodeNew', function (t) {
     public: 'XCesbvDN+9D4momhtlo2BHejPsect6sUzZB2JVm+4v8=.ed25519',
     private:
       'GDwNJNpspHpSwT5BRXoHXj0kmFcRRB31DE5MZPeWUStcJ6xu8M370PiaiaG2WjYEd6M+x5y3qxTNkHYlWb7i/w==.ed25519',
-    id: '@XCesbvDN+9D4momhtlo2BHejPsect6sUzZB2JVm+4v8=.bbfeed-v1',
+    id: 'ssb:feed/bendybutt-v1/XCesbvDN-9D4momhtlo2BHejPsect6sUzZB2JVm-4v8=',
   }
 
   const mainKeys = {
@@ -54,7 +59,7 @@ tape('encodeNew', function (t) {
   }
 
   const mainContent = {
-    type: 'metafeed/add',
+    type: 'metafeed/add/existing',
     feedpurpose: 'main',
     subfeed: mainKeys.id,
     tangles: {
@@ -73,22 +78,22 @@ tape('encodeNew', function (t) {
   t.equal(msgVal1.sequence, 1, 'sequence is correct')
   t.equal(msgVal1.previous, null, 'previous is correct')
   t.equal(msgVal1.timestamp, 12345, 'timestamp is correct')
-  t.equal(msgVal1.signature.substr(0, 6), 'NQQ7Su', 'signature is correct')
+  t.equal(msgVal1.signature.substr(0, 6), 'clLLuA', 'signature is correct')
   t.deepEquals(msgVal1.content, mainContent, 'content is correct')
-  t.equal(msgVal1.contentSignature.substr(0, 6), 'Uazrl3', 'contentSignature')
+  t.equal(msgVal1.contentSignature.substr(0, 6), 'TQPZuS', 'contentSignature')
 
-  const indexKeys = {
+  const indexesKeys = {
     curve: 'ed25519',
     public: '0gC5X4ztZ/YDhTJYbv5ZqPhhvI85Fc8uPSI0tE2p6fw=.ed25519',
     private:
       'giYugk0/HPu3H/NcW6OSVFNXYC5sN0UwJ7VXASjKVF/SALlfjO1n9gOFMlhu/lmo+GG8jzkVzy49IjS0Tanp/A==.ed25519',
-    id: '@0gC5X4ztZ/YDhTJYbv5ZqPhhvI85Fc8uPSI0tE2p6fw=.bbfeed-v1',
+    id: 'ssb:feed/bendybutt-v1/0gC5X4ztZ_YDhTJYbv5ZqPhhvI85Fc8uPSI0tE2p6fw=',
   }
 
-  const indexContent = {
-    type: 'metafeed/add',
-    feedpurpose: 'index',
-    subfeed: indexKeys.id,
+  const indexesContent = {
+    type: 'metafeed/add/derived',
+    feedpurpose: 'indexes',
+    subfeed: indexesKeys.id,
     tangles: {
       metafeed: {
         root: null,
@@ -97,16 +102,23 @@ tape('encodeNew', function (t) {
     },
   }
 
-  const bbmsg2 = bb.encodeNew(indexContent, indexKeys, mfKeys, 2, msg1ID, 23456)
+  const bbmsg2 = bb.encodeNew(
+    indexesContent,
+    indexesKeys,
+    mfKeys,
+    2,
+    msg1ID,
+    23456
+  )
   const msgVal2 = bb.decode(bbmsg2)
 
   t.equal(msgVal2.author, mfKeys.id, 'author is correct')
   t.equal(msgVal2.sequence, 2, 'sequence is correct')
   t.equal(msgVal2.previous, msg1ID, 'previous is correct')
   t.equal(msgVal2.timestamp, 23456, 'timestamp is correct')
-  t.equal(msgVal2.signature.substr(0, 6), 'yTB/CZ', 'signature is correct')
-  t.deepEquals(msgVal2.content, indexContent, 'content is correct')
-  t.equal(msgVal2.contentSignature.substr(0, 6), 'FNA0Q8', 'contentSignature')
+  t.equal(msgVal2.signature.substr(0, 6), 'bHZmOX', 'signature is correct')
+  t.deepEquals(msgVal2.content, indexesContent, 'content is correct')
+  t.equal(msgVal2.contentSignature.substr(0, 6), '0/J3F5', 'contentSignature')
 
   const msgVal2network = bb.decode(bb.encode(msgVal2))
   t.deepEqual(msgVal2, msgVal2network)
@@ -132,7 +144,7 @@ tape('encodeNew', function (t) {
   t.equal(msgVal3.sequence, 1, 'sequence is correct')
   t.equal(msgVal3.previous, null, 'previous is correct')
   t.equal(msgVal3.timestamp, 12345, 'timestamp is correct')
-  t.equal(msgVal3.signature.substr(0, 6), 'Uzsnm5', 'signature is correct')
+  t.equal(msgVal3.signature.substr(0, 6), 'zITgaq', 'signature is correct')
   t.notEqual(
     msgVal1.signature,
     msgVal3.signature,


### PR DESCRIPTION
@mycognosist This PR builds on top of `remove_double_encode` (that's the target branch once merged), by updating ssb-bfe even further (`2.0.2 => 3.0.0`) to add support for SSB URIs. This should replace `%___.bbmsg-v1` with `ssb:message/bendybutt-v1/___` and replace `@___.bbfeed-v1` with `ssb:feed/bendybutt-v1/___`.