### PR TITLE
Bump ssb-bfe

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "bencode": "^2.0.1",
     "is-canonical-base64": "^1.1.1",
-    "ssb-bfe": "3.1.1",
+    "ssb-bfe": "^3.1.3",
     "ssb-keys": "^8.2.0",
     "ssb-ref": "^2.16.0",
     "ssb-uri2": "^1.5.1"


### PR DESCRIPTION
I noticed that ssb-bfe is hardcoded to 3.1.1 and 3.1.3 has a good [fix](https://github.com/ssb-ngi-pointer/ssb-bfe/pull/33). I thought it might be a good idea to updated the dependencies here.