### PR TITLE
fix toNativeMsg when there is encrypted content

### DIFF
--- a/format.js
+++ b/format.js
@@ -121,8 +121,7 @@ function toNativeMsg(msg, encoding = 'js') {
       content,
       contentSignature,
     } = msg
-    const contentSection =
-      typeof content === 'string' ? content : [content, contentSignature]
+    const contentSection = [content, contentSignature]
     const payload = [author, sequence, previous, timestamp, contentSection]
     const msgBFE = BFE.encode([payload, signature])
     const nativeMsg = bencode.encode(msgBFE)

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "husky": "^4.3.0",
     "prettier": "^2.1.2",
     "pretty-quick": "^3.1.0",
+    "ssb-box": "1.0.1",
     "ssb-feed-format": "^2.0.0",
     "ssb-meta-feeds": "~0.18.2",
     "tap-arc": "^0.3.4",

--- a/test/encrypt.js
+++ b/test/encrypt.js
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2022 Andre 'Staltz' Medeiros
+//
+// SPDX-License-Identifier: CC0-1.0
+
+const tape = require('tape')
+const box = require('ssb-box/format')
+const bendybutt = require('../format')
+
+tape('toNativeMsg supports box2 encrypted content', function (t) {
+  const mfKeys = {
+    curve: 'ed25519',
+    public: 'XCesbvDN+9D4momhtlo2BHejPsect6sUzZB2JVm+4v8=.ed25519',
+    private:
+      'GDwNJNpspHpSwT5BRXoHXj0kmFcRRB31DE5MZPeWUStcJ6xu8M370PiaiaG2WjYEd6M+x5y3qxTNkHYlWb7i/w==.ed25519',
+    id: 'ssb:feed/bendybutt-v1/XCesbvDN-9D4momhtlo2BHejPsect6sUzZB2JVm-4v8=',
+  }
+
+  const mainKeys = {
+    curve: 'ed25519',
+    public: 'd/zDvFswFbQaYJc03i47C9CgDev+/A8QQSfG5l/SEfw=.ed25519',
+    private:
+      'BSq6H1RYSU9PfFjE40TuvEeHiiAWBr6ec8w6lM93f3Z3/MO8WzAVtBpglzTeLjsL0KAN6/78DxBBJ8bmX9IR/A==.ed25519',
+    id: '@d/zDvFswFbQaYJc03i47C9CgDev+/A8QQSfG5l/SEfw=.ed25519',
+  }
+
+  const mainContent = {
+    type: 'metafeed/add/existing',
+    feedpurpose: 'main',
+    subfeed: mainKeys.id,
+    tangles: {
+      metafeed: {
+        root: null,
+        previous: null,
+      },
+    },
+  }
+
+  const opts = {
+    keys: mfKeys,
+    contentKeys: mainKeys,
+    content: mainContent,
+    timestamp: 12345,
+    previous: null,
+    hmacKey: null,
+  }
+
+  const ptxt = bendybutt.toPlaintextBuffer(opts)
+  const ctxt = box.encrypt(ptxt, { recps: [mainKeys.id] })
+
+  const nativeMsg = bendybutt.newNativeMsg({
+    ...opts,
+    content: ctxt.toString('base64') + '.box',
+  })
+
+  bendybutt.validate(nativeMsg, null, null, (err) => {
+    t.error(err, 'no validate error')
+
+    const msgVal = bendybutt.fromNativeMsg(nativeMsg)
+    const nativeMsg2 = bendybutt.toNativeMsg(msgVal)
+
+    bendybutt.validate(nativeMsg2, null, null, (err) => {
+      t.error(err, 'no validate error')
+      t.end()
+    })
+  })
+})


### PR DESCRIPTION
## Context

I'm putting ssb-meta-feeds in ssb-tribes2 and bumped into a problem when ssb-tribes2 encrypts (on the shard feed) a `metafeed/add/derived` message announcing a group feed.

## Problem

Validation fails on an encrypted message **if** that message has passed through `toNativeMsg`. Turns out there was an incorrect line of code inside `toNativeMsg`.

## Solution

1st :x: 2nd :heavy_check_mark: 